### PR TITLE
Advay final touches

### DIFF
--- a/backend/passport.js
+++ b/backend/passport.js
@@ -1,16 +1,17 @@
 "use strict";
 
-var passport = require("passport"),
+const passport = require("passport"), 
   TwitterTokenStrategy = require("passport-twitter-token"),
   User = require("mongoose").model("User"),
-  twitterConfig = require("./twitter.config.js");
+  TWITTER_CONSUMER_KEY = process.env.TWITTER_CONSUMER_KEY,
+  TWITTER_CONSUMER_SECRET = process.env.TWITTER_CONSUMER_SECRET;;
 
 module.exports = function() {
   passport.use(
     new TwitterTokenStrategy(
       {
-        consumerKey: twitterConfig.consumerKey,
-        consumerSecret: twitterConfig.consumerSecret
+        consumerKey: TWITTER_CONSUMER_KEY,
+        consumerSecret: TWITTER_CONSUMER_SECRET
         // includeEmail: true
       },
       function(token, tokenSecret, profile, done) {

--- a/backend/twitter.config.js
+++ b/backend/twitter.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  consumerKey: "glcrgP7IoJ3OKaMoQt0JDenHC",
-  consumerSecret: "GU7PyseSsxMiaklsuoXuL66lSKvnO4M7zkXhpLuHb1dPONHyHJ"
-};

--- a/scilla/Twitter.scilla
+++ b/scilla/Twitter.scilla
@@ -29,6 +29,7 @@ let tweet_exists_code = Uint32 6
 let tweet_not_valid_code = Uint32 7
 let tweet_valid_code = Uint32 8
 let not_oracle_code = Uint32 9
+let tweet_within_day_code = Uint32 10
 
 (* TODO: Challenge - Use this to teach students to change variables to fields *)
 let zils_per_tweet = Uint128 10000
@@ -54,31 +55,14 @@ let lte =
         let a_eq_b = builtin eq a b in
         orb a_lt_b a_eq_b
 
-(* Update the withdrawal time if above a day *)
-(* or, update the amount if below a day *)
 let update_withdrawal =
     fun (last_withdrawal: Pair (BNum) (Uint128)) =>
     fun (current_block: BNum) =>
     fun (withdraw_amount: Uint128) =>
-        let last_withdraw_block = fst_withdraw last_withdrawal in
         let cumulative_amount = snd_withdraw last_withdrawal in
-        let next_day_block = builtin badd last_withdraw_block blocks_per_day in
-        let not_next_day_yet = builtin blt current_block next_day_block in
         let new_amount = builtin add cumulative_amount withdraw_amount in
         let in_limit = lte new_amount withdrawal_limit_per_day in
         let none_withdrawal = None {(Pair BNum Uint128)} in
-        match not_next_day_yet with
-        | True =>
-            match in_limit with
-            | True =>
-                let new_withdrawal = Pair {BNum Uint128} last_withdraw_block new_amount in
-                let some_withdrawal = Some {(Pair (BNum) (Uint128))} new_withdrawal in
-                some_withdrawal
-            | False =>
-                none_withdrawal
-            end
-        | False =>
-            (* TODO: Buggy, this needs to be fixed, it's the same as the old stuff*)
             match in_limit with
             | True =>
                 let new_withdrawal = Pair {BNum Uint128} current_block new_amount in
@@ -87,7 +71,6 @@ let update_withdrawal =
             | False =>
                 none_withdrawal
             end
-        end
 
 
 
@@ -270,56 +253,69 @@ transition verify_tweet(
                     send msgs
                 | True =>
 
-                    new_tweet = Pair {ByStr20 Bool} user_address true;
-                    verifying_tweets[tweet_id] := new_tweet;
-
                     withdrawal <- last_withdrawal[user_address];
                     current_block <- & BLOCKNUMBER;
 
-                    new_withdrawal =
-                        match withdrawal with
-                        | None =>
-                            let new_withdrawal = Pair {BNum Uint128} current_block zils_per_tweet in
-                            new_withdrawal
-                        | Some withdrawal =>
-                            let new_withdrawal = update_withdrawal withdrawal current_block zils_per_tweet in
-                            match new_withdrawal with
+                    last_withdraw_block = fst_withdraw last_withdrawal in
+                    next_day_block = builtin badd last_withdraw_block blocks_per_day in
+                    not_next_day_yet = builtin blt current_block next_day_block in
+
+                    match not_next_day_yet with
+                    | False =>
+                        msg = {_tag: "";
+                            _recipient: user_address;
+                            _amount: zero;
+                            code: tweet_within_day_code};
+                        msgs = one_msg msg;
+                        send msgs 
+                    | True =>
+                        new_tweet = Pair {ByStr20 Bool} user_address true;
+                        verifying_tweets[tweet_id] := new_tweet;
+                        new_withdrawal =
+                            match withdrawal with
                             | None =>
-                                withdrawal
-                            | Some new_withdrawal =>
+                                let new_withdrawal = Pair {BNum Uint128} current_block zils_per_tweet in
                                 new_withdrawal
+                            | Some withdrawal =>
+                                let new_withdrawal = update_withdrawal withdrawal current_block zils_per_tweet in
+                                match new_withdrawal with
+                                | None =>
+                                    withdrawal
+                                | Some new_withdrawal =>
+                                    new_withdrawal
+                                end
                             end
-                        end
-                    ;
+                        ;
 
-                    last_withdrawal[user_address] := new_withdrawal;
+                        last_withdrawal[user_address] := new_withdrawal;
 
-                    (* Find the difference between new withdrawal and old withdrawal *)
-                    reward_amount =
-                        match withdrawal with
-                        (* No prior withdrawals, just withdraw the tweet *)
-                        | None =>
-                            zils_per_tweet
-                        | Some withdrawal =>
-                            let old_balance = snd_withdraw withdrawal in
-                            let new_balance = snd_withdraw new_withdrawal in
-                            let reward_amount = builtin sub new_balance old_balance in
-                            reward_amount
-                        end
-                    ;
+                        (* Find the difference between new withdrawal and old withdrawal *)
+                        reward_amount =
+                            match withdrawal with
+                            (* No prior withdrawals, just withdraw the tweet *)
+                            | None =>
+                                zils_per_tweet
+                            | Some withdrawal =>
+                                let old_balance = snd_withdraw withdrawal in
+                                let new_balance = snd_withdraw new_withdrawal in
+                                let reward_amount = builtin sub new_balance old_balance in
+                                reward_amount
+                            end
+                        ;
 
-                    e = {_eventname : "verify_tweet";
-                        recipient: user_address;
-                        reward_amount: reward_amount;
-                        tweet_id: tweet_id};
-                    event e;
+                        e = {_eventname : "verify_tweet";
+                            recipient: user_address;
+                            reward_amount: reward_amount;
+                            tweet_id: tweet_id};
+                        event e;
 
-                    msg = {_tag: "";
-                        _recipient: user_address;
-                        _amount: reward_amount;
-                        code: tweet_valid_code};
-                    msgs = one_msg msg;
-                    send msgs
+                        msg = {_tag: "";
+                            _recipient: user_address;
+                            _amount: reward_amount;
+                            code: tweet_valid_code};
+                        msgs = one_msg msg;
+                        send msgs
+                    end
                 end
                 
             end

--- a/scilla/Twitter.scilla
+++ b/scilla/Twitter.scilla
@@ -31,9 +31,9 @@ let tweet_valid_code = Uint32 8
 let not_oracle_code = Uint32 9
 
 (* TODO: Challenge - Use this to teach students to change variables to fields *)
-let zils_per_tweet = Uint128 10000000000000
+let zils_per_tweet = Uint128 10000
 let blocks_per_day = Uint32 20
-let withdrawal_limit_per_day = Uint128 1000000000000000
+let withdrawal_limit_per_day = Uint128 10000
 
 let str_exists = @list_exists String
 let fst_tweet = @fst ByStr20 Bool
@@ -78,6 +78,7 @@ let update_withdrawal =
                 none_withdrawal
             end
         | False =>
+            (* TODO: Buggy, this needs to be fixed, it's the same as the old stuff*)
             match in_limit with
             | True =>
                 let new_withdrawal = Pair {BNum Uint128} current_block new_amount in

--- a/scilla/Twitter.scilla
+++ b/scilla/Twitter.scilla
@@ -18,6 +18,7 @@ let false = False
 let true = True
 let zero = Uint128 0
 let one = Uint32 1
+let zero_32_bit = Uint32 0
 
 let accepted_code = Uint32 0
 let not_owner_code = Uint32 1
@@ -227,6 +228,12 @@ transition verify_tweet(
             is_matching_address = builtin eq recipient_address user_address;
             is_valid = andb is_matching_address not_verified_tweet;
 
+            tweet_length = builtin strlen tweet_text;
+            valid_start_pos = lte zero_32_bit start_pos;
+            valid_end_pos = builtin lt end_pos tweet_text;
+            is_valid_substring = andb valid_start_pos valid_end_pos;
+            is_valid = andb is_valid_substring is_valid;
+
             match is_valid with
             | False =>
                 msg = {_tag: "";
@@ -236,10 +243,8 @@ transition verify_tweet(
                 msgs = one_msg msg;
                 send msgs
             | True =>
-
                 substr_len = builtin sub end_pos start_pos;
                 substr_len = builtin add substr_len one;
-                (* TODO: Should defend against exception where end_pos larger than string length *)
                 match_hashtag = builtin substr tweet_text start_pos substr_len;
                 is_hashtag = builtin eq match_hashtag hashtag;
 
@@ -256,9 +261,9 @@ transition verify_tweet(
                     withdrawal <- last_withdrawal[user_address];
                     current_block <- & BLOCKNUMBER;
 
-                    last_withdraw_block = fst_withdraw last_withdrawal in
-                    next_day_block = builtin badd last_withdraw_block blocks_per_day in
-                    not_next_day_yet = builtin blt current_block next_day_block in
+                    last_withdraw_block = fst_withdraw last_withdrawal;
+                    next_day_block = builtin badd last_withdraw_block blocks_per_day;
+                    not_next_day_yet = builtin blt current_block next_day_block;
 
                     match not_next_day_yet with
                     | False =>

--- a/scilla/Twitter.scilla
+++ b/scilla/Twitter.scilla
@@ -18,7 +18,6 @@ let false = False
 let true = True
 let zero = Uint128 0
 let one = Uint32 1
-let zero_32_bit = Uint32 0
 
 let accepted_code = Uint32 0
 let not_owner_code = Uint32 1
@@ -32,7 +31,6 @@ let tweet_valid_code = Uint32 8
 let not_oracle_code = Uint32 9
 let tweet_within_day_code = Uint32 10
 
-(* TODO: Challenge - Use this to teach students to change variables to fields *)
 let zils_per_tweet = Uint128 10000
 let blocks_per_day = Uint32 20
 let withdrawal_limit_per_day = Uint128 10000
@@ -72,8 +70,6 @@ let update_withdrawal =
             | False =>
                 none_withdrawal
             end
-
-
 
 (***************************************************)
 (*             The contract definition             *)
@@ -189,7 +185,6 @@ transition new_tweet(tweet_id: String)
             msgs = one_msg msg;
             send msgs
         end
-
     end
 end
 
@@ -229,8 +224,18 @@ transition verify_tweet(
             is_valid = andb is_matching_address not_verified_tweet;
 
             tweet_length = builtin strlen tweet_text;
-            valid_start_pos = lte zero_32_bit start_pos;
-            valid_end_pos = builtin lt end_pos tweet_text;
+            valid_start_pos =
+                let start_pos_128_option = builtin to_uint128 start_pos in
+                match start_pos_128_option with
+                | None =>
+                    False
+                | Some start_pos_128 =>
+                    let is_non_negative = lte zero start_pos_128 in
+                    is_non_negative
+                end
+            ;
+            string_length = builtin strlen tweet_text;
+            valid_end_pos = builtin lt end_pos string_length;
             is_valid_substring = andb valid_start_pos valid_end_pos;
             is_valid = andb is_valid_substring is_valid;
 
@@ -260,20 +265,27 @@ transition verify_tweet(
 
                     withdrawal <- last_withdrawal[user_address];
                     current_block <- & BLOCKNUMBER;
-
-                    last_withdraw_block = fst_withdraw last_withdrawal;
-                    next_day_block = builtin badd last_withdraw_block blocks_per_day;
-                    not_next_day_yet = builtin blt current_block next_day_block;
-
+                    not_next_day_yet =
+                        match withdrawal with
+                        | Some withdrawal =>
+                            let last_withdraw_block = fst_withdraw withdrawal in
+                            let next_day_block = builtin badd last_withdraw_block blocks_per_day in
+                            let not_next_day_yet = builtin blt current_block next_day_block in
+                            not_next_day_yet
+                        | None =>
+                            False    
+                        end
+                    ;
+                    
                     match not_next_day_yet with
-                    | False =>
+                    | True =>
                         msg = {_tag: "";
                             _recipient: user_address;
                             _amount: zero;
                             code: tweet_within_day_code};
                         msgs = one_msg msg;
                         send msgs 
-                    | True =>
+                    | False =>
                         new_tweet = Pair {ByStr20 Bool} user_address true;
                         verifying_tweets[tweet_id] := new_tweet;
                         new_withdrawal =
@@ -321,10 +333,8 @@ transition verify_tweet(
                         msgs = one_msg msg;
                         send msgs
                     end
-                end
-                
+                end       
             end
         end
     end
-
 end


### PR DESCRIPTION
The following changes have been made to the contract:

1. Changing `zils_per_tweet` and `withdrawal_limit_per_day` to `10000` ZILs each
2. Adding error checks in case of invalid substring positions
3. Changing the contract to only verify a tweet if it is not on the same day (Previously it could potentially verify a tweet even if the withdrawal failed)
4. Removing the possibility of a withdrawal being valid if on the same day (The earlier code allowed for this functionality, but this isn't required if `zils_per_tweet` and `withdrawal_limit_per_day` are always equal)